### PR TITLE
fix: make SIGINT/SIGTERM actually cancel the load test (#28)

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -149,7 +149,7 @@ Flux is a high-performance, container-native load testing tool built in Rust. Th
 **Flow**:
 1. Initialize logging with tracing
 2. Load and validate configuration
-3. Setup graceful shutdown handler
+3. Setup graceful shutdown handler shared with the executor (`Cancellation`)
 4. Create metrics collector
 5. Display initial banner
 6. Start executor
@@ -302,7 +302,9 @@ scenarios:
 
 - Invalid JSONPath: Log warning, continue
 - Network errors: Record as failed request
-- Signal handling: Clean shutdown on SIGTERM
+- Signal handling: `SIGINT`/`SIGTERM` cancel the run through a shared
+  cancellation token (`src/cancel.rs`); workers stop between requests,
+  interruptible sleeps wake immediately, and reports are still generated
 
 ## Security Considerations
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,27 @@ Run `flux --help` for the complete flag reference.
 
 ---
 
+## 🛑 Stopping a Test Early
+
+`SIGINT` (Ctrl+C) and `SIGTERM` both cancel a running test immediately and take
+the same shutdown path:
+
+- no new workers are started and no new requests are issued;
+- ramp-up pauses, think time, retry delays, and the sync-mode pacing delay wake
+  up right away instead of waiting out their configured duration;
+- in-flight requests are awaited, or end through the configured `timeout`;
+- the terminal summary and the JSON/HTML/CSV reports are still generated from
+  the requests that completed before cancellation.
+
+Because the run stops early, the reported duration and throughput cover only the
+elapsed part of the test.
+
+```bash
+docker run --rm --name flux-run ... flux:latest
+# in another shell
+docker stop flux-run     # SIGTERM: reports are still written
+```
+
 ## 📈 Metrics Collected
 
 Flux collects comprehensive metrics for each request:
@@ -459,6 +480,7 @@ See the `samples/` directory for complete examples:
 flux/
 ├── src/
 │   ├── main.rs              # Entry point and orchestration
+│   ├── cancel.rs            # Cooperative cancellation token
 │   ├── config.rs            # YAML configuration parsing
 │   ├── client.rs            # HTTP client wrapper
 │   ├── executor.rs          # Load test execution engine

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+use tokio::time::sleep;
+
+/// Cooperative cancellation shared between the signal handler and every worker.
+///
+/// Cloning shares the same underlying state, so a single `cancel()` is observed
+/// by all holders. Cancellation is one-way: once requested it stays requested.
+#[derive(Debug, Clone)]
+pub struct Cancellation {
+    sender: Arc<watch::Sender<bool>>,
+    receiver: watch::Receiver<bool>,
+}
+
+impl Cancellation {
+    /// Create a new, not-yet-cancelled token.
+    pub fn new() -> Self {
+        let (sender, receiver) = watch::channel(false);
+        Self {
+            sender: Arc::new(sender),
+            receiver,
+        }
+    }
+
+    /// Request cancellation. Repeated calls are harmless.
+    pub fn cancel(&self) {
+        let _ = self.sender.send(true);
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        *self.receiver.borrow()
+    }
+
+    /// Resolve as soon as cancellation is requested.
+    pub async fn cancelled(&self) {
+        let mut receiver = self.receiver.clone();
+        if *receiver.borrow() {
+            return;
+        }
+        // The sender is held by this token, so `changed()` only fails if the
+        // channel closed, which cannot happen while `self` is alive.
+        while receiver.changed().await.is_ok() {
+            if *receiver.borrow() {
+                return;
+            }
+        }
+    }
+
+    /// Sleep for `duration` unless cancellation happens first.
+    ///
+    /// Returns `false` when the sleep was cut short by cancellation.
+    pub async fn sleep(&self, duration: Duration) -> bool {
+        if duration.is_zero() {
+            return !self.is_cancelled();
+        }
+
+        tokio::select! {
+            biased;
+            _ = self.cancelled() => false,
+            _ = sleep(duration) => true,
+        }
+    }
+}
+
+impl Default for Cancellation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[tokio::test]
+    async fn test_cancel_is_observed_by_clones() {
+        let token = Cancellation::new();
+        let clone = token.clone();
+
+        assert!(!clone.is_cancelled());
+        token.cancel();
+        assert!(clone.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_sleep_returns_early_on_cancel() {
+        let token = Cancellation::new();
+        let canceller = token.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(20)).await;
+            canceller.cancel();
+        });
+
+        let started = Instant::now();
+        let completed = token.sleep(Duration::from_secs(30)).await;
+
+        assert!(!completed);
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_sleep_completes_without_cancel() {
+        let token = Cancellation::new();
+        assert!(token.sleep(Duration::from_millis(5)).await);
+        assert!(token.sleep(Duration::ZERO).await);
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_resolves_when_already_cancelled() {
+        let token = Cancellation::new();
+        token.cancel();
+        token.cancelled().await;
+    }
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,3 +1,4 @@
+use crate::cancel::Cancellation;
 use crate::client::HttpClient;
 use crate::config::{Config, ResponseAssertions, Scenario};
 use crate::metrics::{MetricsCollector, RequestResult};
@@ -7,7 +8,7 @@ use jsonpath_rust::JsonPath;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::time::{sleep, Duration};
+use tokio::time::Duration;
 use tracing::{debug, error, warn};
 
 /// Executor for running load tests
@@ -15,16 +16,22 @@ pub struct Executor {
     config: Config,
     client: HttpClient,
     metrics: Arc<MetricsCollector>,
+    cancellation: Cancellation,
 }
 
 impl Executor {
     /// Create a new executor
-    pub fn new(config: Config, metrics: Arc<MetricsCollector>) -> Result<Self> {
+    pub fn new(
+        config: Config,
+        metrics: Arc<MetricsCollector>,
+        cancellation: Cancellation,
+    ) -> Result<Self> {
         let client = HttpClient::new(config.parse_timeout()?)?;
         Ok(Self {
             config,
             client,
             metrics,
+            cancellation,
         })
     }
 
@@ -48,6 +55,12 @@ impl Executor {
             worker_start_delay(self.config.concurrency, ramp_up, self.config.mode == "sync");
 
         for worker_id in 0..self.config.concurrency {
+            // Stop spawning additional workers once cancellation is requested.
+            if self.cancellation.is_cancelled() {
+                debug!("Cancellation requested; not starting worker {}", worker_id);
+                break;
+            }
+
             let executor = self.clone_for_worker();
             let start_clone = start;
             let duration_clone = duration;
@@ -59,8 +72,12 @@ impl Executor {
             });
 
             handles.push(handle);
-            if worker_id + 1 < self.config.concurrency && !start_delay.is_zero() {
-                sleep(start_delay).await;
+            if worker_id + 1 < self.config.concurrency
+                && !start_delay.is_zero()
+                && !self.cancellation.sleep(start_delay).await
+            {
+                debug!("Cancellation requested during ramp-up");
+                break;
             }
         }
 
@@ -76,7 +93,7 @@ impl Executor {
     async fn worker_loop(&self, worker_id: usize, start: Instant, duration: Duration) {
         debug!("Worker {} started", worker_id);
 
-        while start.elapsed() < duration {
+        while start.elapsed() < duration && !self.cancellation.is_cancelled() {
             if self.config.is_simple_mode() {
                 self.execute_simple_request().await;
                 if let Some(think_time) = self
@@ -84,15 +101,19 @@ impl Executor {
                     .parse_think_time()
                     .expect("Validated think_time became invalid")
                 {
-                    sleep(think_time).await;
+                    if !self.cancellation.sleep(think_time).await {
+                        break;
+                    }
                 }
             } else {
                 self.execute_scenarios().await;
             }
 
             // Small delay in sync mode
-            if self.config.mode == "sync" {
-                sleep(Duration::from_millis(10)).await;
+            if self.config.mode == "sync"
+                && !self.cancellation.sleep(Duration::from_millis(10)).await
+            {
+                break;
             }
         }
 
@@ -124,6 +145,7 @@ impl Executor {
             let end_time = Utc::now();
 
             if attempt < self.config.retry_count
+                && !self.cancellation.is_cancelled()
                 && should_retry_response(&result, &self.config.retry_on_status)
             {
                 attempt += 1;
@@ -132,8 +154,8 @@ impl Executor {
                     attempt,
                     self.config.retry_count.saturating_add(1)
                 );
-                if !retry_delay.is_zero() {
-                    sleep(retry_delay).await;
+                if !self.cancellation.sleep(retry_delay).await {
+                    break (result, start_time, end_time, latency);
                 }
                 continue;
             }
@@ -180,6 +202,11 @@ impl Executor {
         let mut executed: HashSet<String> = HashSet::new();
 
         for scenario in &self.config.scenarios {
+            if self.cancellation.is_cancelled() {
+                debug!("Cancellation requested; stopping scenario sequence");
+                break;
+            }
+
             // Check dependencies
             if let Some(ref depends_on) = scenario.depends_on {
                 if !Self::has_executed_scenario(depends_on, &executed) {
@@ -209,7 +236,10 @@ impl Executor {
                 let latency = request_start.elapsed().as_millis() as u64;
                 let end_time = Utc::now();
 
-                if attempt < retry_count && should_retry_response(&result, retry_statuses) {
+                if attempt < retry_count
+                    && !self.cancellation.is_cancelled()
+                    && should_retry_response(&result, retry_statuses)
+                {
                     attempt += 1;
                     debug!(
                         "Retrying scenario '{}' after attempt {} of {}",
@@ -217,8 +247,8 @@ impl Executor {
                         attempt,
                         retry_count.saturating_add(1)
                     );
-                    if !retry_delay.is_zero() {
-                        sleep(retry_delay).await;
+                    if !self.cancellation.sleep(retry_delay).await {
+                        break (result, start_time, end_time, latency);
                     }
                     continue;
                 }
@@ -306,7 +336,9 @@ impl Executor {
                 .parse_think_time_for(scenario)
                 .expect("Validated scenario think_time became invalid")
             {
-                sleep(think_time).await;
+                if !self.cancellation.sleep(think_time).await {
+                    break;
+                }
             }
         }
     }
@@ -356,6 +388,7 @@ impl Executor {
             client: HttpClient::new(self.config.parse_timeout().expect("Invalid timeout"))
                 .expect("Failed to create client"),
             metrics: Arc::clone(&self.metrics),
+            cancellation: self.cancellation.clone(),
         }
     }
 }
@@ -415,6 +448,7 @@ mod tests {
     use crate::config::OutputConfig;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::time::sleep;
 
     #[test]
     fn test_executor_creation() {
@@ -444,7 +478,7 @@ mod tests {
         };
 
         let metrics = Arc::new(MetricsCollector::new());
-        let executor = Executor::new(config, metrics);
+        let executor = Executor::new(config, metrics, Cancellation::new());
 
         assert!(executor.is_ok());
     }
@@ -523,7 +557,7 @@ mod tests {
             },
         };
         let metrics = Arc::new(MetricsCollector::new());
-        let executor = Executor::new(config, Arc::clone(&metrics)).unwrap();
+        let executor = Executor::new(config, Arc::clone(&metrics), Cancellation::new()).unwrap();
 
         executor.execute_simple_request().await;
         server.await.unwrap();
@@ -558,5 +592,130 @@ mod tests {
             body_contains: None,
         };
         assert!(response_status_error(404, false, Some(&assertions)).is_none());
+    }
+
+    /// Accept connections until dropped, always answering with `status`.
+    async fn spawn_status_server(
+        status: u16,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut request = [0_u8; 1024];
+                    let _ = socket.read(&mut request).await;
+                    let response = format!(
+                        "HTTP/1.1 {status} OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        (address, handle)
+    }
+
+    fn cancellation_test_config(target: String) -> Config {
+        Config {
+            target: Some(target),
+            method: Some("GET".to_string()),
+            headers: HashMap::new(),
+            body: None,
+            multipart: None,
+            scenarios: vec![],
+            concurrency: 1,
+            duration: "300s".to_string(),
+            timeout: "5s".to_string(),
+            ramp_up: None,
+            think_time: None,
+            retry_count: 0,
+            retry_delay: None,
+            retry_on_status: vec![],
+            assertions: None,
+            prometheus_port: None,
+            mode: "async".to_string(),
+            output: OutputConfig {
+                json: "output.json".to_string(),
+                html: "output.html".to_string(),
+                csv: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_stops_active_run() {
+        let (address, server) = spawn_status_server(200).await;
+        let config = cancellation_test_config(format!("http://{address}"));
+        let metrics = Arc::new(MetricsCollector::new());
+        let cancellation = Cancellation::new();
+        let executor = Executor::new(config, Arc::clone(&metrics), cancellation.clone()).unwrap();
+
+        let canceller = cancellation.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            canceller.cancel();
+        });
+
+        let started = Instant::now();
+        executor.run(300).await.unwrap();
+        server.abort();
+
+        // Without cancellation this would run for the configured 300 seconds.
+        assert!(started.elapsed() < Duration::from_secs(30));
+        assert!(!metrics.get_results().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_during_ramp_up_stops_spawning_workers() {
+        let (address, server) = spawn_status_server(200).await;
+        let mut config = cancellation_test_config(format!("http://{address}"));
+        config.concurrency = 20;
+        config.ramp_up = Some("200s".to_string());
+        let metrics = Arc::new(MetricsCollector::new());
+        let cancellation = Cancellation::new();
+        let executor = Executor::new(config, Arc::clone(&metrics), cancellation.clone()).unwrap();
+
+        let canceller = cancellation.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            canceller.cancel();
+        });
+
+        let started = Instant::now();
+        executor.run(300).await.unwrap();
+        server.abort();
+
+        // Each worker start is 10s apart, so only cancellation can end this quickly.
+        assert!(started.elapsed() < Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_interrupts_retry_delay() {
+        let (address, server) = spawn_status_server(503).await;
+        let mut config = cancellation_test_config(format!("http://{address}"));
+        config.retry_count = 3;
+        config.retry_delay = Some("120s".to_string());
+        config.retry_on_status = vec![503];
+        let metrics = Arc::new(MetricsCollector::new());
+        let cancellation = Cancellation::new();
+        let executor = Executor::new(config, Arc::clone(&metrics), cancellation.clone()).unwrap();
+
+        let canceller = cancellation.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            canceller.cancel();
+        });
+
+        let started = Instant::now();
+        executor.execute_simple_request().await;
+        server.abort();
+
+        assert!(started.elapsed() < Duration::from_secs(30));
+        let results = metrics.get_results();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].status_code, 503);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cancel;
 mod client;
 mod config;
 mod executor;
@@ -7,6 +8,7 @@ mod reporter;
 mod ui;
 
 use anyhow::Result;
+use cancel::Cancellation;
 use clap::Parser;
 use config::Config;
 use executor::Executor;
@@ -16,7 +18,6 @@ use reporter::Reporter;
 use signal_hook::consts::{SIGINT, SIGTERM};
 use signal_hook_tokio::Signals;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::time::{interval, Duration};
 use tracing::{error, info};
@@ -108,21 +109,26 @@ async fn main() -> Result<()> {
     let ui = TerminalUI::new(duration_secs);
     ui.display_banner(&config, duration_secs);
 
-    // Setup graceful shutdown
-    let shutdown_flag = Arc::new(AtomicBool::new(false));
-    let shutdown_flag_clone = Arc::clone(&shutdown_flag);
+    // Setup graceful shutdown: SIGINT and SIGTERM share one cancellation path.
+    let cancellation = Cancellation::new();
+    let signal_cancellation = cancellation.clone();
 
     tokio::spawn(async move {
         use futures::stream::StreamExt;
         let mut signals = Signals::new([SIGTERM, SIGINT]).expect("Failed to create signal handler");
         if let Some(signal) = signals.next().await {
-            info!("Received signal: {:?}", signal);
-            shutdown_flag_clone.store(true, Ordering::SeqCst);
+            let name = match signal {
+                SIGINT => "SIGINT",
+                SIGTERM => "SIGTERM",
+                _ => "signal",
+            };
+            info!("Received {name}; stopping the load test and generating reports");
+            signal_cancellation.cancel();
         }
     });
 
     // Create executor
-    let executor = match Executor::new(config.clone(), Arc::clone(&metrics)) {
+    let executor = match Executor::new(config.clone(), Arc::clone(&metrics), cancellation.clone()) {
         Ok(exec) => exec,
         Err(e) => {
             ui.display_error(&format!("Failed to create executor: {}", e));
@@ -149,12 +155,17 @@ async fn main() -> Result<()> {
 
     // Start live metrics update task
     let metrics_clone = Arc::clone(&metrics);
+    let ui_cancellation = cancellation.clone();
     let ui_handle = tokio::spawn(async move {
         let mut ticker = interval(Duration::from_secs(1));
         let mut elapsed = 0u64;
 
         loop {
-            ticker.tick().await;
+            tokio::select! {
+                biased;
+                _ = ui_cancellation.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
             elapsed += 1;
 
             let live_metrics = metrics_clone.get_live_metrics();
@@ -194,6 +205,9 @@ async fn main() -> Result<()> {
 
     // Display summary in terminal
     let ui = TerminalUI::new(duration_secs);
+    if cancellation.is_cancelled() {
+        ui.display_warning("Load test cancelled early; reporting completed requests only");
+    }
     ui.display_summary(&summary);
 
     // Generate reports

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -193,6 +193,11 @@ impl TerminalUI {
         eprintln!("\n{} {}", "❌ Error:".bright_red().bold(), message);
     }
 
+    /// Display warning message
+    pub fn display_warning(&self, message: &str) {
+        println!("\n{} {}", "⚠️  Warning:".bright_yellow().bold(), message);
+    }
+
     /// Display success message
     pub fn display_success(&self, message: &str) {
         println!("\n{} {}", "✅".bright_green(), message);


### PR DESCRIPTION
Closes #28.

**Stack 1/5** — base of the bug-fix stack. Merge order: this → #30 → #31 → #32 → #29.

## Problem

`main.rs` installed handlers for `SIGINT`/`SIGTERM` and set an `AtomicBool` that nothing ever read. `Executor` had no cancellation input and only exited when `start.elapsed() >= duration`, so Ctrl+C did not stop a run, and ramp-up, think-time and retry sleeps ran to completion regardless.

## Change

- New `src/cancel.rs`: a cloneable `Cancellation` token over a `watch` channel (`cancel`, `is_cancelled`, `cancelled().await`, and an interruptible `sleep`). No new dependency — `tokio` is already present.
- `Executor::new` takes the token, shared with `main`; workers check it before each request and between scenario steps.
- Ramp-up, think-time, retry and sync-mode delays go through `Cancellation::sleep`, so they wake immediately instead of finishing their delay.
- No further workers are spawned once cancellation is requested; already-running workers are awaited before reports are produced.
- The live-metrics UI task stops on cancellation, so the terminal summary and the JSON/HTML/CSV reports are written promptly from completed results.
- `SIGINT` and `SIGTERM` share one path and log the reason once; the summary notes that the run was cancelled early.

## Tests

Six new tests: token semantics and early-waking sleeps (`cancel.rs`), plus cancellation during an active run, during ramp-up, and during a retry delay against a local HTTP listener. `cargo test` passes (33 tests at this point in the stack).

Verified against the real binary: `SIGTERM` on a run configured for 300s exits in ~2s with a complete summary, JSON, HTML and CSV.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHMnfbeqQRJn2MTBiNWeKo)_