### PR TITLE
fix: reject invalid scenario dependency graphs before running (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,19 +254,39 @@ output:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Step name |
+| `name` | string | Yes | Step name; must be non-empty and unique |
 | `method` | string | Yes | HTTP method |
 | `url` | string | Yes | URL path or full URL |
 | `headers` | map | No | HTTP headers |
 | `body` | string | No | Request body |
 | `multipart` | array | No | Multipart form data |
 | `extract` | map | No | JSONPath extraction rules |
-| `depends_on` | string | No | Name of step this depends on |
+| `depends_on` | string | No | Name of an **earlier** step this depends on |
 | `think_time` | string | No | Pause after this step |
 | `retry_count` | integer | No | Override the global retry count |
 | `retry_delay` | string | No | Override the global retry delay |
 | `retry_on_status` | array | No | Override global retryable statuses |
 | `assert` | object | No | Expected `status_code` and/or `body_contains` value |
+
+### Scenario Dependencies
+
+`depends_on` names another step in the same list. Because scenarios execute in
+declaration order, the referenced step must be declared **before** the step that
+uses it. Flux checks the whole scenario graph while loading the configuration
+and refuses to start when it finds:
+
+- an empty or duplicated scenario name;
+- a `depends_on` value naming a scenario that does not exist (a typo);
+- a step that depends on itself;
+- a step that depends on a later step — which also rules out dependency cycles.
+
+These are configuration mistakes, so they fail before a single request is sent
+instead of silently turning a user journey into a partial load test.
+
+At runtime a dependency can still fail — a bad response, a failed assertion, a
+network error. The dependent step is then skipped for that iteration, and the
+skip is counted per step in the terminal summary, the JSON report
+(`summary.skipped_scenarios`) and the HTML report.
 
 ### Quality Gates
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,6 +264,8 @@ impl Config {
             }
         }
 
+        self.validate_scenario_graph()?;
+
         // Validate scenarios
         for scenario in &self.scenarios {
             parse_optional_duration(scenario.think_time.as_deref())?;
@@ -300,6 +302,75 @@ impl Config {
                         );
                     }
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate scenario names and the `depends_on` graph.
+    ///
+    /// Scenarios run in declaration order, so a dependency must name an
+    /// earlier step. Enforcing that here turns typos, duplicate names and
+    /// cycles into configuration errors instead of silently skipped work.
+    fn validate_scenario_graph(&self) -> anyhow::Result<()> {
+        let mut positions: HashMap<&str, usize> = HashMap::new();
+
+        for (index, scenario) in self.scenarios.iter().enumerate() {
+            let step = index + 1;
+            if scenario.name.trim().is_empty() {
+                anyhow::bail!("Scenario at step {step} has an empty 'name'");
+            }
+            if let Some(previous) = positions.insert(scenario.name.as_str(), index) {
+                anyhow::bail!(
+                    "Duplicate scenario name '{}' at steps {} and {}; \
+                     scenario names must be unique because 'depends_on' refers to them",
+                    scenario.name,
+                    previous + 1,
+                    step
+                );
+            }
+        }
+
+        for (index, scenario) in self.scenarios.iter().enumerate() {
+            let Some(depends_on) = scenario.depends_on.as_deref() else {
+                continue;
+            };
+
+            if depends_on.trim().is_empty() {
+                anyhow::bail!(
+                    "Scenario '{}' has an empty 'depends_on'; remove it or name an earlier step",
+                    scenario.name
+                );
+            }
+            if depends_on == scenario.name {
+                anyhow::bail!(
+                    "Scenario '{}' depends on itself; a step cannot wait for its own result",
+                    scenario.name
+                );
+            }
+
+            match positions.get(depends_on) {
+                None => anyhow::bail!(
+                    "Scenario '{}' depends on unknown scenario '{}'; declared scenarios are: {}",
+                    scenario.name,
+                    depends_on,
+                    self.scenarios
+                        .iter()
+                        .map(|scenario| format!("'{}'", scenario.name))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                Some(&dependency_index) if dependency_index > index => anyhow::bail!(
+                    "Scenario '{}' (step {}) depends on '{}' (step {}), which runs later; \
+                     scenarios execute in declaration order, so a dependency must be \
+                     declared before the step that uses it",
+                    scenario.name,
+                    index + 1,
+                    depends_on,
+                    dependency_index + 1
+                ),
+                Some(_) => {}
             }
         }
 
@@ -775,6 +846,137 @@ mod tests {
         );
     }
 
+    fn scenario(name: &str, depends_on: Option<&str>) -> Scenario {
+        Scenario {
+            name: name.to_string(),
+            method: "GET".to_string(),
+            url: "/".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            multipart: None,
+            extract: HashMap::new(),
+            depends_on: depends_on.map(ToString::to_string),
+            think_time: None,
+            retry_count: None,
+            retry_delay: None,
+            retry_on_status: None,
+            assertions: None,
+        }
+    }
+
+    fn scenario_config(scenarios: Vec<Scenario>) -> Config {
+        Config {
+            target: Some("http://example.com".to_string()),
+            method: Some("GET".to_string()),
+            headers: HashMap::new(),
+            body: None,
+            multipart: None,
+            scenarios,
+            concurrency: 1,
+            duration: "1s".to_string(),
+            timeout: "1s".to_string(),
+            ramp_up: None,
+            think_time: None,
+            retry_count: 0,
+            retry_delay: None,
+            retry_on_status: vec![],
+            assertions: None,
+            prometheus_port: None,
+            mode: "async".to_string(),
+            output: OutputConfig {
+                json: "output.json".to_string(),
+                html: "output.html".to_string(),
+                csv: None,
+            },
+        }
+    }
+
+    #[test]
+    fn test_valid_dependency_chain_is_accepted() {
+        let config = scenario_config(vec![
+            scenario("login", None),
+            scenario("get-profile", Some("login")),
+            scenario("logout", Some("get-profile")),
+        ]);
+
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_unknown_dependency_is_rejected() {
+        let config = scenario_config(vec![
+            scenario("login", None),
+            scenario("get-profile", Some("logn")),
+        ]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("unknown scenario 'logn'"), "{error}");
+        assert!(error.contains("'login'"), "{error}");
+    }
+
+    #[test]
+    fn test_duplicate_scenario_names_are_rejected() {
+        let config = scenario_config(vec![
+            scenario("login", None),
+            scenario("checkout", None),
+            scenario("login", None),
+        ]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("Duplicate scenario name 'login'"), "{error}");
+        assert!(error.contains("steps 1 and 3"), "{error}");
+    }
+
+    #[test]
+    fn test_empty_scenario_name_is_rejected() {
+        let config = scenario_config(vec![scenario("  ", None)]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("step 1 has an empty 'name'"), "{error}");
+    }
+
+    #[test]
+    fn test_self_dependency_is_rejected() {
+        let config = scenario_config(vec![scenario("login", Some("login"))]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("depends on itself"), "{error}");
+    }
+
+    #[test]
+    fn test_empty_dependency_is_rejected() {
+        let config = scenario_config(vec![scenario("login", Some("  "))]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("empty 'depends_on'"), "{error}");
+    }
+
+    #[test]
+    fn test_forward_dependency_is_rejected() {
+        let config = scenario_config(vec![
+            scenario("get-profile", Some("login")),
+            scenario("login", None),
+        ]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("which runs later"), "{error}");
+        assert!(error.contains("declaration order"), "{error}");
+    }
+
+    #[test]
+    fn test_dependency_cycle_is_rejected() {
+        // A cycle always contains at least one step that depends on a later
+        // step, so it cannot survive validation.
+        let config = scenario_config(vec![
+            scenario("a", Some("b")),
+            scenario("b", Some("c")),
+            scenario("c", Some("a")),
+        ]);
+
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("runs later"), "{error}");
+    }
+
     #[test]
     fn test_aggregate_assertion_evaluation() {
         let config = Config {
@@ -826,6 +1028,7 @@ mod tests {
             start_time: chrono::Utc::now(),
             end_time: chrono::Utc::now(),
             per_scenario: Default::default(),
+            skipped_scenarios: Default::default(),
         };
 
         let failures = config.evaluate_assertions(&summary);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -214,11 +214,15 @@ impl Executor {
 
             // Check dependencies
             if let Some(ref depends_on) = scenario.depends_on {
+                // Configuration validation guarantees the dependency exists and
+                // runs earlier, so reaching this point means it failed at
+                // runtime. Count the skip so reports show the lost work.
                 if !Self::has_executed_scenario(depends_on, &executed) {
                     warn!(
-                        "Skipping scenario '{}' - dependency '{}' not met",
+                        "Skipping scenario '{}' - dependency '{}' did not succeed",
                         scenario.name, depends_on
                     );
+                    self.metrics.record_skipped_scenario(&scenario.name);
                     continue;
                 }
             }
@@ -748,6 +752,56 @@ mod tests {
                 csv: None,
             },
         }
+    }
+
+    #[tokio::test]
+    async fn test_runtime_dependency_failure_is_counted_as_skipped() {
+        let (address, server) = spawn_status_server(500).await;
+        let mut config = cancellation_test_config(format!("http://{address}"));
+        config.scenarios = vec![
+            Scenario {
+                name: "login".to_string(),
+                method: "GET".to_string(),
+                url: "/login".to_string(),
+                headers: HashMap::new(),
+                body: None,
+                multipart: None,
+                extract: HashMap::new(),
+                depends_on: None,
+                think_time: None,
+                retry_count: None,
+                retry_delay: None,
+                retry_on_status: None,
+                assertions: None,
+            },
+            Scenario {
+                name: "profile".to_string(),
+                method: "GET".to_string(),
+                url: "/profile".to_string(),
+                headers: HashMap::new(),
+                body: None,
+                multipart: None,
+                extract: HashMap::new(),
+                depends_on: Some("login".to_string()),
+                think_time: None,
+                retry_count: None,
+                retry_delay: None,
+                retry_on_status: None,
+                assertions: None,
+            },
+        ];
+        let metrics = Arc::new(MetricsCollector::new());
+        let executor = Executor::new(config, Arc::clone(&metrics), Cancellation::new()).unwrap();
+
+        executor.execute_scenarios().await;
+        server.abort();
+
+        let summary = metrics.generate_summary();
+        // The dependency failed at runtime, so the dependent step is skipped
+        // and the skip is visible in the report instead of vanishing.
+        assert_eq!(summary.skipped_scenarios.get("profile"), Some(&1));
+        assert!(!summary.per_scenario.contains_key("profile"));
+        assert_eq!(summary.failed_requests, 1);
     }
 
     #[tokio::test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,6 +23,7 @@ pub struct MetricsCollector {
     histogram: Arc<Mutex<Histogram<u64>>>,
     start_time: DateTime<Utc>,
     load_phase: Arc<Mutex<LoadPhase>>,
+    skipped_scenarios: Arc<Mutex<BTreeMap<String, usize>>>,
 }
 
 /// Tracks when the full-concurrency phase began and how much work it did.
@@ -62,6 +63,11 @@ pub struct MetricsSummary {
     pub start_time: DateTime<Utc>,
     pub end_time: DateTime<Utc>,
     pub per_scenario: BTreeMap<String, ScenarioMetricsSummary>,
+    /// Scenario steps skipped at runtime because a dependency failed, and how
+    /// often. Configuration mistakes never reach this map: they fail the run
+    /// before any request is sent.
+    #[serde(default)]
+    pub skipped_scenarios: BTreeMap<String, usize>,
 }
 
 /// Summary statistics for one named scenario step.
@@ -100,6 +106,15 @@ impl MetricsCollector {
             )),
             start_time: Utc::now(),
             load_phase: Arc::new(Mutex::new(LoadPhase::default())),
+            skipped_scenarios: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    /// Record a scenario step that was skipped because the step it depends on
+    /// failed during this iteration.
+    pub fn record_skipped_scenario(&self, name: &str) {
+        if let Ok(mut skipped) = self.skipped_scenarios.lock() {
+            *skipped.entry(name.to_string()).or_default() += 1;
         }
     }
 
@@ -270,6 +285,11 @@ impl MetricsCollector {
             start_time: self.start_time,
             end_time,
             per_scenario,
+            skipped_scenarios: self
+                .skipped_scenarios
+                .lock()
+                .map(|skipped| skipped.clone())
+                .unwrap_or_default(),
         }
     }
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -218,6 +218,7 @@ mod tests {
             start_time: Utc::now(),
             end_time: Utc::now(),
             per_scenario: Default::default(),
+            skipped_scenarios: Default::default(),
         };
 
         let reporter = Reporter::new(summary, results);
@@ -258,6 +259,7 @@ mod tests {
             start_time: Utc::now(),
             end_time: Utc::now(),
             per_scenario: Default::default(),
+            skipped_scenarios: Default::default(),
         };
         let reporter = Reporter::new(summary, vec![result]);
         let path = std::env::temp_dir().join(format!(
@@ -310,6 +312,7 @@ mod tests {
             start_time: Utc::now(),
             end_time: Utc::now(),
             per_scenario: std::collections::BTreeMap::from([("login".to_string(), scenario)]),
+            skipped_scenarios: Default::default(),
         };
         let reporter = Reporter::new(summary, Vec::new());
 

--- a/src/templates/report.html
+++ b/src/templates/report.html
@@ -210,6 +210,30 @@
                 {% endif %}
             </div>
 
+            {% if summary.skipped_scenarios | length > 0 %}
+            <!-- Skipped Steps -->
+            <div class="chart-section">
+                <h2>Skipped Steps</h2>
+                <p>These steps were skipped because the step they depend on failed at runtime.</p>
+                <table class="percentiles-table">
+                    <thead>
+                        <tr>
+                            <th>Scenario</th>
+                            <th>Times Skipped</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for name, count in summary.skipped_scenarios %}
+                        <tr>
+                            <td>{{ name }}</td>
+                            <td class="error">{{ count }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% endif %}
+
             {% if summary.per_scenario | length > 0 %}
             <!-- Per-Scenario Metrics -->
             <div class="chart-section">

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -128,6 +128,22 @@ impl TerminalUI {
             }
         );
 
+        if !summary.skipped_scenarios.is_empty() {
+            println!(
+                "\n{}",
+                "Skipped Steps (dependency failed at runtime):"
+                    .bright_yellow()
+                    .bold()
+            );
+            for (name, count) in &summary.skipped_scenarios {
+                println!(
+                    "  {:<25} : {}",
+                    name.bright_white(),
+                    count.to_string().bright_yellow()
+                );
+            }
+        }
+
         // Performance metrics
         println!("\n{}", "Performance Metrics:".bright_green().bold());
         println!(
@@ -260,6 +276,7 @@ mod tests {
             start_time: Utc::now(),
             end_time: Utc::now(),
             per_scenario: Default::default(),
+            skipped_scenarios: Default::default(),
         };
 
         // This will print to stdout, but we're just testing it doesn't panic


### PR DESCRIPTION
Closes #31.

**Stack 3/5** — targets #39. Review only the top commit.

## Problem

`depends_on` was resolved only at execution time against the set of steps that had already succeeded. A typo, an unknown name, a self-dependency or an out-of-order declaration just logged a warning and skipped work, silently turning a multi-step user journey into a partial load test.

## Change

- `Config::validate` builds an index of scenario names and checks the graph up front, rejecting: empty names, duplicate names, empty or unknown `depends_on` values, self-dependencies, and dependencies on a **later** step. Because scenarios execute in declaration order, that last rule also makes cycles impossible. Every message names the offending steps (`"Duplicate scenario name 'login' at steps 1 and 3"`, `"depends on unknown scenario 'logn'; declared scenarios are: 'login', ..."`).
- Runtime dependency failures remain a legitimate skip, so they are counted per step and surfaced in the terminal summary, the JSON report (`summary.skipped_scenarios`) and the HTML report, rather than only appearing in a log line.
- README documents the constraints and the runtime behaviour.

## Tests

Nine new tests covering a valid chain, unknown dependency, duplicate names, empty name, self-dependency, empty `depends_on`, forward reference, a three-step cycle, and an executor test asserting a runtime dependency failure is recorded as a skip and not as a scenario metric. `cargo test` passes (46 tests at this point in the stack).

The bundled `samples/scenario-auth.yaml` is valid under the new rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHMnfbeqQRJn2MTBiNWeKo)_