### PR TITLE
fix: interpolate scenario variables in multipart data (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,43 @@ output:
   html: "/app/results/report.html"
 ```
 
+### Multipart Upload With Scenario Variables
+
+Inside scenarios, `{{ variable }}` placeholders are substituted in multipart
+field names, field values and file paths, using variables extracted by earlier
+steps:
+
+```yaml
+scenarios:
+  - name: "login"
+    method: "POST"
+    url: "/login"
+    body: '{"user":"demo","password":"demo"}'
+    extract:
+      token: "$.token"
+      file_name: "$.upload.file_name"
+
+  - name: "upload"
+    method: "POST"
+    url: "/uploads"
+    depends_on: "login"
+    multipart:
+      - type: "field"
+        name: "session"
+        value: "{{ token }}"
+
+      - type: "file"
+        name: "attachment"
+        path: "/app/data/{{ file_name }}"
+```
+
+If a placeholder cannot be resolved — a typo, or a variable no earlier step
+extracted — the step fails with an explicit error and the request is *not*
+sent, so the target never receives a literal `{{ token }}`.
+
+Simple (non-scenario) multipart has no variables to substitute and is sent
+exactly as written.
+
 ### Multi-Step Scenario with Variable Extraction
 
 ```yaml

--- a/src/client.rs
+++ b/src/client.rs
@@ -78,7 +78,8 @@ impl HttpClient {
 
         // Handle multipart or body
         if let Some(parts) = &scenario.multipart {
-            request = self.build_multipart_request(request, parts).await?;
+            let rendered = self.render_multipart_parts(parts, variables, &scenario.name)?;
+            request = self.build_multipart_request(request, &rendered).await?;
         } else if let Some(body_content) = &scenario.body {
             let substituted_body = self.substitute_variables(body_content, variables);
             request = request.body(substituted_body);
@@ -86,6 +87,58 @@ impl HttpClient {
 
         let response = request.send().await?;
         Ok(response)
+    }
+
+    /// Apply scenario variables to every field of each multipart part.
+    ///
+    /// Multipart parts are rendered before the form is built so extracted
+    /// variables reach field names, field values and file paths, exactly as
+    /// they do for the URL, headers and a raw body. A placeholder that no
+    /// variable resolves is a hard error: sending literal `{{ name }}` to the
+    /// target would be an unintended request.
+    fn render_multipart_parts(
+        &self,
+        parts: &[MultipartPart],
+        variables: &HashMap<String, String>,
+        scenario_name: &str,
+    ) -> Result<Vec<MultipartPart>> {
+        parts
+            .iter()
+            .map(|part| {
+                let rendered = MultipartPart {
+                    part_type: self.substitute_variables(&part.part_type, variables),
+                    name: self.substitute_variables(&part.name, variables),
+                    path: part
+                        .path
+                        .as_deref()
+                        .map(|path| self.substitute_variables(path, variables)),
+                    value: part
+                        .value
+                        .as_deref()
+                        .map(|value| self.substitute_variables(value, variables)),
+                };
+
+                let fields = [
+                    ("type", Some(&rendered.part_type)),
+                    ("name", Some(&rendered.name)),
+                    ("path", rendered.path.as_ref()),
+                    ("value", rendered.value.as_ref()),
+                ];
+                for (field, content) in fields {
+                    let Some(content) = content else { continue };
+                    if let Some(placeholder) = unresolved_placeholder(content) {
+                        anyhow::bail!(
+                            "Unresolved variable '{placeholder}' in multipart '{field}' of \
+                             part '{}' in scenario '{scenario_name}'; no earlier step \
+                             extracted it",
+                            part.name
+                        );
+                    }
+                }
+
+                Ok(rendered)
+            })
+            .collect()
     }
 
     /// Build multipart form request
@@ -146,6 +199,15 @@ impl HttpClient {
     }
 }
 
+/// Return the name inside the first `{{ ... }}` placeholder that survived
+/// substitution, if any.
+fn unresolved_placeholder(value: &str) -> Option<String> {
+    let start = value.find("{{")?;
+    let rest = &value[start + 2..];
+    let end = rest.find("}}")?;
+    Some(rest[..end].trim().to_string())
+}
+
 impl Default for HttpClient {
     fn default() -> Self {
         Self::new(Duration::from_secs(30)).expect("Failed to create HTTP client")
@@ -155,6 +217,201 @@ impl Default for HttpClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Scenario;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn multipart_scenario(parts: Vec<MultipartPart>) -> Scenario {
+        Scenario {
+            name: "upload".to_string(),
+            method: "POST".to_string(),
+            url: "/uploads".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            multipart: Some(parts),
+            extract: HashMap::new(),
+            depends_on: None,
+            think_time: None,
+            retry_count: None,
+            retry_delay: None,
+            retry_on_status: None,
+            assertions: None,
+        }
+    }
+
+    /// Accept one request, return everything that was sent, then answer 200.
+    async fn capture_one_request(listener: TcpListener) -> String {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut received = Vec::new();
+        let mut chunk = [0_u8; 4096];
+
+        loop {
+            match tokio::time::timeout(Duration::from_millis(300), socket.read(&mut chunk)).await {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(read)) => received.extend_from_slice(&chunk[..read]),
+                Ok(Err(_)) => break,
+            }
+        }
+
+        let _ = socket
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await;
+        String::from_utf8_lossy(&received).into_owned()
+    }
+
+    fn temp_file(name: &str, contents: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn test_scenario_variables_render_in_multipart() {
+        let unique = format!("{}-{}", std::process::id(), line!());
+        let file_name = format!("flux-upload-{unique}.txt");
+        let file_path = temp_file(&file_name, "uploaded contents");
+        let directory = file_path.parent().unwrap().display().to_string();
+
+        let scenario = multipart_scenario(vec![
+            MultipartPart {
+                part_type: "field".to_string(),
+                name: "{{ field_name }}".to_string(),
+                path: None,
+                value: Some("{{ token }}".to_string()),
+            },
+            MultipartPart {
+                part_type: "file".to_string(),
+                name: "attachment".to_string(),
+                path: Some(format!("{directory}/{{{{ file_name }}}}")),
+                value: None,
+            },
+        ]);
+        let variables = HashMap::from([
+            ("field_name".to_string(), "session".to_string()),
+            ("token".to_string(), "abc123".to_string()),
+            ("file_name".to_string(), file_name.clone()),
+        ]);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(capture_one_request(listener));
+
+        let client = HttpClient::default();
+        let response = client
+            .execute_scenario(Some(&format!("http://{address}")), &scenario, &variables)
+            .await
+            .unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+
+        let request = server.await.unwrap();
+        std::fs::remove_file(&file_path).unwrap();
+
+        assert!(request.contains("name=\"session\""), "{request}");
+        assert!(request.contains("abc123"), "{request}");
+        assert!(request.contains("name=\"attachment\""), "{request}");
+        assert!(
+            request.contains(&format!("filename=\"{file_name}\"")),
+            "{request}"
+        );
+        assert!(request.contains("uploaded contents"), "{request}");
+        assert!(!request.contains("{{"), "{request}");
+    }
+
+    #[tokio::test]
+    async fn test_unresolved_multipart_placeholder_is_rejected_before_sending() {
+        let scenario = multipart_scenario(vec![MultipartPart {
+            part_type: "field".to_string(),
+            name: "session".to_string(),
+            path: None,
+            value: Some("{{ token }}".to_string()),
+        }]);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let client = HttpClient::default();
+        let error = client
+            .execute_scenario(
+                Some(&format!("http://{address}")),
+                &scenario,
+                &HashMap::new(),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("Unresolved variable 'token'"), "{error}");
+        assert!(error.contains("scenario 'upload'"), "{error}");
+        // Nothing was dispatched, so no connection was ever accepted.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), listener.accept())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_multipart_file_still_reports_rendered_path() {
+        let scenario = multipart_scenario(vec![MultipartPart {
+            part_type: "file".to_string(),
+            name: "attachment".to_string(),
+            path: Some("/does/not/exist/{{ file_name }}".to_string()),
+            value: None,
+        }]);
+        let variables = HashMap::from([("file_name".to_string(), "missing.txt".to_string())]);
+
+        let client = HttpClient::default();
+        let error = client
+            .execute_scenario(Some("http://127.0.0.1:1"), &scenario, &variables)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("File not found: /does/not/exist/missing.txt"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_simple_mode_multipart_is_not_substituted() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(capture_one_request(listener));
+
+        let client = HttpClient::default();
+        let parts = vec![MultipartPart {
+            part_type: "field".to_string(),
+            name: "session".to_string(),
+            value: Some("{{ token }}".to_string()),
+            path: None,
+        }];
+        let response = client
+            .execute_simple(
+                &format!("http://{address}"),
+                "POST",
+                &HashMap::new(),
+                None,
+                Some(&parts),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+
+        let request = server.await.unwrap();
+        // Simple mode has no scenario variables, so values are sent verbatim.
+        assert!(request.contains("{{ token }}"), "{request}");
+    }
+
+    #[test]
+    fn test_unresolved_placeholder_detection() {
+        assert_eq!(
+            unresolved_placeholder("/data/{{ file_name }}").as_deref(),
+            Some("file_name")
+        );
+        assert_eq!(unresolved_placeholder("/data/file.txt"), None);
+        assert_eq!(unresolved_placeholder("{{ unclosed"), None);
+    }
 
     #[test]
     fn test_substitute_variables() {


### PR DESCRIPTION
Closes #32.

**Stack 4/5** — targets #40. Review only the top commit.

## Problem

`HttpClient::execute_scenario` passed `MultipartPart` values straight to `build_multipart_request`; substitution only happened in the non-multipart body branch. A scenario that extracted a token or file name then uploaded the literal text `{{ token }}`, and a templated file path never resolved.

## Change

- Scenario multipart parts are rendered before the form is built, so the same `{{ variable }}` rules apply to a part's `type`, `name`, `value` and `path`.
- A placeholder that no variable resolves aborts the step with an error naming the variable, the field and the scenario — **before** anything is dispatched, so the target never receives literal braces.
- Missing files keep their existing descriptive error, now reporting the rendered path.
- Simple-mode multipart has no scenario variables and is unchanged.
- README gains a multipart scenario-variable example.

## Tests

Five new tests, four of them against a local TCP listener that captures the raw request: rendered field name/value and file name/content in the multipart body, an unresolved placeholder that produces a clear error and never opens a connection, a missing file reporting the rendered path, and simple mode passing `{{ token }}` through verbatim. `cargo test` passes (51 tests at this point in the stack).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHMnfbeqQRJn2MTBiNWeKo)_